### PR TITLE
updated `ns_spp_search()` and `handle_sptax()` to include "kingdom" field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .Rhistory
 .Rproj.user
+natserv.Rproj
 taxize_.Rproj
 taxize.Rproj
 README.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .Rhistory
 .Rproj.user
+*.Rproj
 natserv.Rproj
 taxize_.Rproj
 taxize.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: 'NatureServe' Interface
 Description: Interface to 'NatureServe' (<https://www.natureserve.org/>).
     Includes methods to get data, image metadata, search taxonomic names,
     and make maps.
-Version: 1.0.0.91
+Version: 1.0.0.92
 License: MIT + file LICENSE
 URL: https://docs.ropensci.org/natserv/, https://github.com/ropensci/natserv
 BugReports: https://github.com/ropensci/natserv/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
 Suggests:
     testthat,
     vcr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 X-schema.org-applicationCategory: Taxonomy
 X-schema.org-keywords: taxonomy, species, API, web-services, NatureServe, metadata, maps
 X-schema.org-isPartOf: https://ropensci.org

--- a/R/ns_search_spp.R
+++ b/R/ns_search_spp.R
@@ -17,8 +17,10 @@
 #' ns_search_spp(status = "G1")
 #' ns_search_spp(location = list(nation = "US"))
 #' ns_search_spp(location = list(nation = "US", subnation = "VA"))
-#' ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Animalia", level = "kingdom"))
-#' ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Lepidoptera", level = "order", kingdom = "Animalia")) 
+#' ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Animalia"
+#'      , level = "kingdom"))
+#' ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Lepidoptera"
+#'      , level = "order", kingdom = "Animalia")) 
 #' ns_search_spp(species_taxonomy = list(informalTaxonomy = "birds"))
 #' ns_search_spp(record_subtype = "macrogroup")
 #' ns_search_spp(modified_since = "2020-04-30T00:00:00+0000")

--- a/R/ns_search_spp.R
+++ b/R/ns_search_spp.R
@@ -2,10 +2,12 @@
 #'
 #' @export
 #' @inheritParams ns_search_comb
-#' @param species_taxonomy (list) species taxonomy. either a list with
-#' `level` and `scientificTaxonomy` (a scientific name), or with just
-#' `informalTaxonomy` (a vernacular name). possible `level` values:
-#' "kingdom", "phylum", "class", "order", "family", "genus" 
+#' @param species_taxonomy (list) species taxonomy. either a list with `level`,
+#'   `scientificTaxonomy` (a scientific name), and optionally, `kingdom`, or
+#'   with just `informalTaxonomy` (a vernacular name). If a `level!="kingdom"`, 
+#'   `kingdom` must be supplied in list when using
+#'   `scientificTaxonomy`. Possible `level` values:
+#'   "kingdom", "phylum", "class", "order", "family", "genus".
 #' @template ns
 #' @family search
 #' @examples \dontrun{
@@ -16,6 +18,7 @@
 #' ns_search_spp(location = list(nation = "US"))
 #' ns_search_spp(location = list(nation = "US", subnation = "VA"))
 #' ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Animalia", level = "kingdom"))
+#' ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Lepidoptera", level = "order", kingdom = "Animalia")) 
 #' ns_search_spp(species_taxonomy = list(informalTaxonomy = "birds"))
 #' ns_search_spp(record_subtype = "macrogroup")
 #' ns_search_spp(modified_since = "2020-04-30T00:00:00+0000")

--- a/R/search_helpers.R
+++ b/R/search_helpers.R
@@ -75,10 +75,10 @@ handle_sptax <- function(st) {
   if (!is.null(st)) {
     if (
       !all(names(st) %in% 
-        c("level", "scientificTaxonomy", "informalTaxonomy"))
+        c("level", "scientificTaxonomy", "informalTaxonomy", "kingdom"))
     ) {
       stop("`species_taxonomy` must be a list w/ 'informalTaxonomy' ",
-        "or 'level' and 'scientificTaxonomy'",
+        "or 'level', and 'scientificTaxonomy'. if 'level' other than `kingdom` is used, supply 'kingdom' as well",
         call. = FALSE)
     }
     pt <- if ("informalTaxonomy" %in% names(st)) 

--- a/man/ns_search_spp.Rd
+++ b/man/ns_search_spp.Rd
@@ -31,10 +31,12 @@ G5, GH, GX, GNR, GNA, GU. case insensitive}
 \item{location}{(list) location, country and sub-country. specify either
 \code{nation} OR \code{nation} and \code{subnation}. each expects a two-letter ISO code}
 
-\item{species_taxonomy}{(list) species taxonomy. either a list with
-\code{level} and \code{scientificTaxonomy} (a scientific name), or with just
-\code{informalTaxonomy} (a vernacular name). possible \code{level} values:
-"kingdom", "phylum", "class", "order", "family", "genus"}
+\item{species_taxonomy}{(list) species taxonomy. either a list with \code{level},
+\code{scientificTaxonomy} (a scientific name), and optionally, \code{kingdom}, or
+with just \code{informalTaxonomy} (a vernacular name). If a \code{level!="kingdom"},
+\code{kingdom} must be supplied in list when using
+\code{scientificTaxonomy}. Possible \code{level} values:
+"kingdom", "phylum", "class", "order", "family", "genus".}
 
 \item{record_subtype}{(character) limit results by record sub-type, one of:
 "class", "subclass", "formation", "division", "macrogroup", "group",
@@ -62,6 +64,7 @@ ns_search_spp(status = "G1")
 ns_search_spp(location = list(nation = "US"))
 ns_search_spp(location = list(nation = "US", subnation = "VA"))
 ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Animalia", level = "kingdom"))
+ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Lepidoptera", level = "order", kingdom = "Animalia")) 
 ns_search_spp(species_taxonomy = list(informalTaxonomy = "birds"))
 ns_search_spp(record_subtype = "macrogroup")
 ns_search_spp(modified_since = "2020-04-30T00:00:00+0000")

--- a/man/ns_search_spp.Rd
+++ b/man/ns_search_spp.Rd
@@ -63,8 +63,10 @@ ns_search_spp(text_adv = list(searchToken = "bird",
 ns_search_spp(status = "G1")
 ns_search_spp(location = list(nation = "US"))
 ns_search_spp(location = list(nation = "US", subnation = "VA"))
-ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Animalia", level = "kingdom"))
-ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Lepidoptera", level = "order", kingdom = "Animalia")) 
+ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Animalia"
+     , level = "kingdom"))
+ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Lepidoptera"
+     , level = "order", kingdom = "Animalia")) 
 ns_search_spp(species_taxonomy = list(informalTaxonomy = "birds"))
 ns_search_spp(record_subtype = "macrogroup")
 ns_search_spp(modified_since = "2020-04-30T00:00:00+0000")


### PR DESCRIPTION


## Description
Modified "ns_search_spp.R" and "search_helpers.R" to allow users to input "kingdom" when searching with the "Scientific Taxonomy Parameter". Added examples that work (didn't include the one that fails, which specifies `level !="kingdom"` but doesn't supply `kingdom`). I'm new to versioning conventions so I added one to the smallest decimal in the `DESCRIPTION` file as well 

## Related Issue
Fix #25 

## Example
This still fails: 
`ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Lepidoptera" ,  level = "order"))`
But this now works:
`ns_search_spp(species_taxonomy = list(scientificTaxonomy = "Lepidoptera" ,  level = "order", kingdom = "Animalia"))` 

I did not create a new test as the current test should, generally, capture that the changes work. 

